### PR TITLE
Update adaptive_softmax.py build method.

### DIFF
--- a/adaptive_softmax.py
+++ b/adaptive_softmax.py
@@ -40,8 +40,8 @@ class AdaptiveSoftmax(tf.keras.layers.Layer):
         if self.proj_dims:
             assert len(self.proj_dims)==self.cluster_num
         else:
-            self.proj_dims = [tf.math.maximum(hidden_dim/self.proj_factor**i, 1)
-            for i in range(1, self.cluster_num+1)]
+            self.proj_dims = [int(tf.math.maximum(hidden_dim/self.proj_factor**i, 1).numpy()) 
+                  for i in range(1, self.cluster_num+1)]
 
         # initialize dense layers for head. reserve cluster_num spots for
         # each cluster probability


### PR DESCRIPTION
handles self.project_dims from

self.proj_dims = [tf.math.maximum(hidden_dim/self.proj_factor**i, 1)
                  for i in range(1, self.cluster_num+1)]

to

self.proj_dims = [int(tf.math.maximum(hidden_dim/self.proj_factor**i, 1).numpy()) 
                  for i in range(1, self.cluster_num+1)]

The former kept returning invalid datatype error, the later fixed it.